### PR TITLE
aligned question circle icon inside button

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -363,6 +363,14 @@ img {
 
 .button--icon {
   margin-right: 10px;
+  vertical-align: middle;
+}
+
+.button--icon.icon-question-circle-o {
+
+  position: relative;
+  top: -2px;
+
 }
 
 .button-group {

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -367,10 +367,8 @@ img {
 }
 
 .button--icon.icon-question-circle-o {
-
   position: relative;
   top: -2px;
-
 }
 
 .button-group {


### PR DESCRIPTION
Fixes #78 

## Description

- Moves the icon to fit in with the text

🐧 