### PR TITLE
Set timeout to 1 hour.

### DIFF
--- a/src/Messages.elm
+++ b/src/Messages.elm
@@ -37,7 +37,7 @@ type alias GaEvent =
 
 pageTimeoutSecs : Float
 pageTimeoutSecs =
-    900
+    3600
 
 
 delay : Float -> msg -> Cmd msg


### PR DESCRIPTION
Fixes #136

## Description

- Timeout after an hour rather than 15mins to see if this cuts down on traffic to that page.


@neontribe/contemplating-action
