### PR TITLE
1.0/168 generic tests passing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The output of different versions of elm-format varies significantly, so please u
 ## Deployment
 
 ### To staging (GitHub pages) with Travis
-We're using [Travis](travis-ci.org).
+We're using [Travis](https://travis-ci.org).
 - On every push to the repo, Travis will build and run tests
 - To trigger a deploy to gh-pages, create and push a tag (e.g. `git tag v1.0.0 && git push origin --tags`
 Encrypted vars can be added to `.travis.yml` using the travis cli tools as decribed in the [travis docs](https://docs.travis-ci.com/user/encryption-keys/#usage).

--- a/src/I18n/En.elm
+++ b/src/I18n/En.elm
@@ -266,6 +266,12 @@ enStrings key =
         InfoNotFoundName ->
             "Not found"
 
+        InfoNotFoundSlug ->
+            "not-found"
+
+        InfoNotFoundIcon ->
+            "question"
+
         InfoNotFoundP1 ->
             "We can't find a page with that title, sorry."
 

--- a/src/I18n/Keys.elm
+++ b/src/I18n/Keys.elm
@@ -95,6 +95,8 @@ type Key
     | InfoLikeOtherInfoLink
     | InfoOtherInfoLink
     | InfoNotFoundName
+    | InfoNotFoundSlug
+    | InfoNotFoundIcon
     | InfoNotFoundP1
     | InfoNotFoundP2
     | InfoOneName

--- a/src/Info.elm
+++ b/src/Info.elm
@@ -12,10 +12,10 @@ import Messages exposing (Msg(..))
 
 type alias Info =
     { id : Int
-    , icon : String
-    , name : String
-    , slug : String
-    , infoText : List String
+    , icon : Key
+    , name : Key
+    , slug : Key
+    , infoText : List Key
     }
 
 
@@ -23,51 +23,55 @@ type alias Info =
 -- Helpers
 
 
-getInfo : Language -> Int -> Info
-getInfo language infoId =
+getInfo : Int -> Info
+getInfo infoId =
     let
         foundInfo =
-            List.head (List.filter (\i -> i.id == infoId) (infoList language))
+            List.head (List.filter (\i -> i.id == infoId) infoList)
     in
     case foundInfo of
         Just info ->
             info
 
         Nothing ->
-            placeholderInfo language
+            placeholderInfo
 
 
 getInfoBySlug : Language -> String -> Info
-getInfoBySlug language infoSlug =
+getInfoBySlug language slug =
     let
         foundInfo =
-            List.head (List.filter (\i -> i.slug == infoSlug) (infoList language))
+            List.head (List.filter (\i -> translate language i.slug == slug) infoList)
     in
     case foundInfo of
         Just info ->
             info
 
         Nothing ->
-            placeholderInfo language
+            placeholderInfo
 
 
 
 -- Views
 
 
-infoCard : Info -> Html Msg
-infoCard info =
+infoCard : Language -> Info -> Html Msg
+infoCard language info =
+    let
+        t =
+            translate language
+    in
     li []
         [ a
             [ class "card card--alternate info"
-            , href ("#/info-to-help/" ++ info.slug)
+            , href ("#/info-to-help/" ++ t info.slug)
 
             -- Record page source because same event will register from click to info from a story page.
-            , onClick (ButtonPress "information" "view-single" info.slug True)
+            , onClick (ButtonPress "information" "view-single" (t info.slug) True)
             ]
-            [ getIcon info.icon (Just "icon info--icon")
+            [ getIcon (t info.icon) (Just "icon info--icon")
             , span [ class "info--text" ]
-                [ span [ class "link link--stateless" ] [ text info.name ] ]
+                [ span [ class "link link--stateless" ] [ text (t info.name) ] ]
             , span [] [ span [] [ getIcon "arrow-right" Nothing ] ]
             ]
         ]
@@ -83,10 +87,10 @@ infoPage language info =
         [ div [ class "section section--align-bottom" ]
             [ div [ class "card card--alternate card--with-icon" ]
                 [ div [ class "text-center" ]
-                    [ getIcon info.icon (Just "icon icon--large card--icon")
+                    [ getIcon (t info.icon) (Just "icon icon--large card--icon")
                     , article [ class "inset" ]
-                        [ h2 [] [ text info.name ]
-                        , div [] (renderParas info.infoText)
+                        [ h2 [] [ text (t info.name) ]
+                        , div [] (renderParas language info.infoText)
                         ]
                     ]
                 ]
@@ -100,72 +104,68 @@ infoPage language info =
         ]
 
 
-renderParas : List String -> List (Html msg)
-renderParas paras =
-    List.map (\t -> p [] [ text t ]) paras
+renderParas : Language -> List Key -> List (Html msg)
+renderParas language paras =
+    let
+        t =
+            translate language
+    in
+    List.map (\key -> p [] [ text (t key) ]) paras
 
 
 
 -- Info records
 
 
-placeholderInfo : Language -> Info
-placeholderInfo language =
-    let
-        t =
-            translate language
-    in
+placeholderInfo : Info
+placeholderInfo =
     { id = 0
-    , name = t InfoNotFoundName
-    , slug = "not-found"
-    , icon = "question"
+    , name = InfoNotFoundName
+    , slug = InfoNotFoundSlug
+    , icon = InfoNotFoundIcon
     , infoText =
-        [ t InfoNotFoundP1
-        , t InfoNotFoundP2
+        [ InfoNotFoundP1
+        , InfoNotFoundP2
         ]
     }
 
 
-infoList : Language -> List Info
-infoList language =
-    let
-        t =
-            translate language
-    in
+infoList : List Info
+infoList =
     [ { id = 1
-      , name = t InfoOneName
-      , slug = t InfoOneSlug
-      , icon = t InfoOneIcon
-      , infoText = [ t InfoOneP1 ]
+      , name = InfoOneName
+      , slug = InfoOneSlug
+      , icon = InfoOneIcon
+      , infoText = [ InfoOneP1 ]
       }
     , { id = 2
-      , name = t InfoTwoName
-      , slug = t InfoTwoSlug
-      , icon = t InfoTwoIcon
-      , infoText = [ t InfoTwoP1 ]
+      , name = InfoTwoName
+      , slug = InfoTwoSlug
+      , icon = InfoTwoIcon
+      , infoText = [ InfoTwoP1 ]
       }
     , { id = 3
-      , name = t InfoThreeName
-      , slug = t InfoThreeSlug
-      , icon = t InfoThreeIcon
-      , infoText = [ t InfoThreeP1 ]
+      , name = InfoThreeName
+      , slug = InfoThreeSlug
+      , icon = InfoThreeIcon
+      , infoText = [ InfoThreeP1 ]
       }
     , { id = 4
-      , name = t InfoFourName
-      , slug = t InfoFourSlug
-      , icon = t InfoFourIcon
-      , infoText = [ t InfoFourP1 ]
+      , name = InfoFourName
+      , slug = InfoFourSlug
+      , icon = InfoFourIcon
+      , infoText = [ InfoFourP1 ]
       }
     , { id = 5
-      , name = t InfoFiveName
-      , slug = t InfoFiveSlug
-      , icon = t InfoFiveIcon
-      , infoText = [ t InfoFiveP1 ]
+      , name = InfoFiveName
+      , slug = InfoFiveSlug
+      , icon = InfoFiveIcon
+      , infoText = [ InfoFiveP1 ]
       }
     , { id = 6
-      , name = t InfoSixName
-      , slug = t InfoSixSlug
-      , icon = t InfoSixIcon
-      , infoText = [ t InfoSixP1 ]
+      , name = InfoSixName
+      , slug = InfoSixSlug
+      , icon = InfoSixIcon
+      , infoText = [ InfoSixP1 ]
       }
     ]

--- a/src/StoryDeck.elm
+++ b/src/StoryDeck.elm
@@ -99,12 +99,16 @@ storyRelatedInfo language deckId =
 
 getInfoButtons : ( Language, Int ) -> Html Msg
 getInfoButtons ( language, id ) =
+    let
+        t =
+            translate language
+    in
     a
-        [ href ("#/info-to-help/" ++ (getInfo language id).slug)
+        [ href ("#/info-to-help/" ++ t (getInfo id).slug)
         , class "button button--alternate button--full-width"
-        , onClick (ButtonPress "information" "view-single" (getInfo language id).slug True)
+        , onClick (ButtonPress "information" "view-single" (t (getInfo id).slug) True)
         ]
-        [ text (getInfo language id).name ]
+        [ text (t (getInfo id).name) ]
 
 
 card : Language -> Int -> Int -> Html msg

--- a/src/Views/Content.elm
+++ b/src/Views/Content.elm
@@ -169,12 +169,12 @@ view model =
             div [ class "section section--info section--vertical-fill-center" ]
                 [ h2 [] [ text (t InfoTitleH2) ]
                 , ul [ class "info--list" ]
-                    [ infoCard (getInfo model.language 1)
-                    , infoCard (getInfo model.language 2)
-                    , infoCard (getInfo model.language 3)
-                    , infoCard (getInfo model.language 4)
-                    , infoCard (getInfo model.language 5)
-                    , infoCard (getInfo model.language 6)
+                    [ infoCard model.language (getInfo 1)
+                    , infoCard model.language (getInfo 2)
+                    , infoCard model.language (getInfo 3)
+                    , infoCard model.language (getInfo 4)
+                    , infoCard model.language (getInfo 5)
+                    , infoCard model.language (getInfo 6)
                     ]
                 ]
 

--- a/tests/InfoTests.elm
+++ b/tests/InfoTests.elm
@@ -1,6 +1,7 @@
 module InfoTests exposing (all)
 
 import Expect
+import I18n.Keys exposing (Key(..))
 import Info exposing (getInfo)
 import Test exposing (Test, describe, test, todo)
 
@@ -11,67 +12,67 @@ all =
         [ describe "Info name"
             [ test "Index of 1" <|
                 \() ->
-                    (getInfo 1).name |> Expect.equal "About the project"
+                    (getInfo 1).name |> Expect.equal InfoOneName
             , test "Index of 2" <|
                 \() ->
-                    (getInfo 2).name |> Expect.equal "Bite size information"
+                    (getInfo 2).name |> Expect.equal InfoTwoName
             , test "Index of 3" <|
                 \() ->
-                    (getInfo 3).name |> Expect.equal "Visual Storytelling"
+                    (getInfo 3).name |> Expect.equal InfoThreeName
             , test "Index of 4" <|
                 \() ->
-                    (getInfo 4).name |> Expect.equal "What is the survey?"
+                    (getInfo 4).name |> Expect.equal InfoFourName
             , test "Index of 5" <|
                 \() ->
-                    (getInfo 5).name |> Expect.equal "Can my organisation try this?"
+                    (getInfo 5).name |> Expect.equal InfoFiveName
             , test "Index of 500" <|
                 \() ->
-                    (getInfo 500).name |> Expect.equal "Not found"
+                    (getInfo 500).name |> Expect.equal InfoNotFoundName
             ]
         , describe "Info slug"
             [ test "Index of 1" <|
                 \() ->
-                    (getInfo 1).slug |> Expect.equal "about"
+                    (getInfo 1).slug |> Expect.equal InfoOneSlug
             , test "Index of 2" <|
                 \() ->
-                    (getInfo 2).slug |> Expect.equal "bite-size-info"
+                    (getInfo 2).slug |> Expect.equal InfoTwoSlug
             , test "Index of 3" <|
                 \() ->
-                    (getInfo 3).slug |> Expect.equal "visual-storytelling"
+                    (getInfo 3).slug |> Expect.equal InfoThreeSlug
             , test "Index of 4" <|
                 \() ->
-                    (getInfo 4).slug |> Expect.equal "survey"
+                    (getInfo 4).slug |> Expect.equal InfoFourSlug
             , test "Index of 5" <|
                 \() ->
-                    (getInfo 5).slug |> Expect.equal "try-this"
+                    (getInfo 5).slug |> Expect.equal InfoFiveSlug
             , test "Index of 0" <|
                 \() ->
-                    (getInfo 0).slug |> Expect.equal "not-found"
+                    (getInfo 0).slug |> Expect.equal InfoNotFoundSlug
             , test "Index of 500" <|
                 \() ->
-                    (getInfo 500).slug |> Expect.equal "not-found"
+                    (getInfo 500).slug |> Expect.equal InfoNotFoundSlug
             ]
         , describe "Info icon"
             [ test "Index of 1" <|
                 \() ->
-                    (getInfo 1).icon |> Expect.equal "question-circle-o"
+                    (getInfo 1).icon |> Expect.equal InfoOneIcon
             , test "Index of 2" <|
                 \() ->
-                    (getInfo 2).icon |> Expect.equal "info-circle"
+                    (getInfo 2).icon |> Expect.equal InfoTwoIcon
             , test "Index of 3" <|
                 \() ->
-                    (getInfo 3).icon |> Expect.equal "pencil"
+                    (getInfo 3).icon |> Expect.equal InfoThreeIcon
             , test "Index of 4" <|
                 \() ->
-                    (getInfo 4).icon |> Expect.equal "check-square-o"
+                    (getInfo 4).icon |> Expect.equal InfoFourIcon
             , test "Index of 5" <|
                 \() ->
-                    (getInfo 5).icon |> Expect.equal "group"
+                    (getInfo 5).icon |> Expect.equal InfoFiveIcon
             , test "Index of 0" <|
                 \() ->
-                    (getInfo 0).icon |> Expect.equal "question"
+                    (getInfo 0).icon |> Expect.equal InfoNotFoundIcon
             , test "Index of 500" <|
                 \() ->
-                    (getInfo 500).icon |> Expect.equal "question"
+                    (getInfo 500).icon |> Expect.equal InfoNotFoundIcon
             ]
         ]

--- a/tests/StoryDeckTests.elm
+++ b/tests/StoryDeckTests.elm
@@ -1,6 +1,7 @@
 module StoryDeckTests exposing (all)
 
 import Expect
+import I18n.Keys exposing (Key(..))
 import StoryDeck exposing (card, storyRelatedInfo, storyTeaser, storyTitle)
 import Test exposing (Test, describe, test, todo)
 
@@ -11,21 +12,21 @@ all =
         [ describe "Getting Story Title"
             [ test "Index of 1" <|
                 \() ->
-                    storyTitle 1 |> Expect.equal "Our Project"
+                    storyTitle 1 |> Expect.equal StoryOneTitle
             , test "Index of 2" <|
                 \() ->
-                    storyTitle 2 |> Expect.equal "The Haven"
+                    storyTitle 2 |> Expect.equal StoryTwoTitle
             , test "Index of 3" <|
                 \() ->
-                    storyTitle 3 |> Expect.equal "Coming soon"
+                    storyTitle 3 |> Expect.equal StoryNotFoundTitle
             , test "Index of 4" <|
                 \() ->
-                    storyTitle 4 |> Expect.equal "Coming soon"
+                    storyTitle 4 |> Expect.equal StoryNotFoundTitle
             , test "Index of 0" <|
                 \() ->
-                    storyTitle 0 |> Expect.equal "Coming soon"
+                    storyTitle 0 |> Expect.equal StoryNotFoundTitle
             , test "Index of 500" <|
                 \() ->
-                    storyTitle 500 |> Expect.equal "Coming soon"
+                    storyTitle 500 |> Expect.equal StoryNotFoundTitle
             ]
         ]


### PR DESCRIPTION
Fixes #168

## Description

- Info cards return keys
- Tests match keys, not translated strings

@neontribe/contemplating-action
