### PR TITLE
Moved footer to outside main content in html

### DIFF
--- a/src/View.elm
+++ b/src/View.elm
@@ -7,6 +7,7 @@ import Html.Attributes.Aria exposing (role)
 import Messages exposing (Msg)
 import Model exposing (Model, pageSlug)
 import Views.Content
+import Views.Footer
 import Views.Header
 import Views.Nav
 
@@ -20,6 +21,7 @@ view model =
             , Views.Nav.view model
             , main_ [ class "content", role "main" ]
                 [ Views.Content.view model ]
+            , Views.Footer.footerContent
             ]
         ]
     }

--- a/src/Views/Content.elm
+++ b/src/Views/Content.elm
@@ -16,7 +16,6 @@ import Messages exposing (Msg(..))
 import Model exposing (Model)
 import Route exposing (Page(..))
 import StoryDeck exposing (card, storyRelatedInfo, storyTeaser, storyTitle)
-import Views.Footer exposing (footerContent)
 import Views.Pages.Privacy exposing (privacyContent)
 import Views.Pages.Supporters exposing (supportersContent)
 
@@ -112,7 +111,6 @@ view model =
                             ]
                         ]
                     ]
-                , footerContent
                 ]
 
         SupportersPage ->


### PR DESCRIPTION
Fixes #158 

## Description

- Global footer now no longer nested inside main content in HTML

@neontribe/contemplating-action
