### PR TITLE
1.0/201 lists on info cards

### DIFF
--- a/src/Info.elm
+++ b/src/Info.elm
@@ -1,4 +1,4 @@
-module Info exposing (Info, getInfo, getInfoBySlug, infoCard, infoPage)
+module Info exposing (Info, getInfo, getInfoBySlug, infoListItem, infoPage)
 
 import Copy.Keys exposing (Key(..))
 import Copy.Render exposing (toHtml, toString)
@@ -55,8 +55,8 @@ getInfoBySlug slug =
 -- Views
 
 
-infoCard : Info -> Html Msg
-infoCard info =
+infoListItem : Info -> Html Msg
+infoListItem info =
     let
         t =
             toString

--- a/src/Info.elm
+++ b/src/Info.elm
@@ -85,7 +85,7 @@ infoPage info =
     in
     div [ class "section--vertical-fill-center" ]
         [ div [ class "section section--align-bottom" ]
-            [ div [ class "card card--alternate card--with-icon" ]
+            [ div [ class "card card--alternate card--with-icon card--info" ]
                 [ div [ class "text-center" ]
                     [ getIcon (t info.icon) (Just "icon icon--large card--icon")
                     , article [ class "inset" ]

--- a/src/Views/Content.elm
+++ b/src/Views/Content.elm
@@ -11,7 +11,7 @@ import Html exposing (Html, a, article, button, div, h2, iframe, img, p, section
 import Html.Attributes exposing (alt, class, height, href, src)
 import Html.Events exposing (onClick)
 import Icon exposing (getIcon)
-import Info exposing (getInfo, getInfoBySlug, infoCard, infoPage)
+import Info exposing (getInfo, getInfoBySlug, infoListItem, infoPage)
 import Messages exposing (Msg(..))
 import Model exposing (Model)
 import Route exposing (Page(..))
@@ -167,12 +167,12 @@ view model =
             div [ class "section section--info section--vertical-fill-center" ]
                 [ h2 [] [ text (t InfoTitleH2) ]
                 , ul [ class "info--list" ]
-                    [ infoCard (getInfo 1)
-                    , infoCard (getInfo 2)
-                    , infoCard (getInfo 3)
-                    , infoCard (getInfo 4)
-                    , infoCard (getInfo 5)
-                    , infoCard (getInfo 6)
+                    [ infoListItem (getInfo 1)
+                    , infoListItem (getInfo 2)
+                    , infoListItem (getInfo 3)
+                    , infoListItem (getInfo 4)
+                    , infoListItem (getInfo 5)
+                    , infoListItem (getInfo 6)
                     ]
                 ]
 

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -476,6 +476,12 @@ nav,
   margin: auto;
 }
 
+.card--info ul {
+  margin: auto;
+  max-width: 50ch;
+  text-align: left;
+}
+
 .card--thumbnail {
   float: left;
   margin-right: 15px;


### PR DESCRIPTION
Fixes #201 

## Description

- Adds some styling to a list in an info section
- Optionally rename function as we use "card" in a number of places

![image](https://user-images.githubusercontent.com/32434620/62837032-680cd880-bc62-11e9-8860-5795f20a7238.png)

@neontribe/contemplating-action
