### PR TITLE
Change cards into one link

### DIFF
--- a/src/Messages.elm
+++ b/src/Messages.elm
@@ -9,6 +9,7 @@ type
     -- Action
     = ButtonPress String String String Bool
       -- Navigation
+    | NavigateToString String
     | UrlChanged Url.Url
     | LinkClicked Browser.UrlRequest
       -- 0 is unconfirmed, 1 is accept, 2 is decline

--- a/src/StoryDeck.elm
+++ b/src/StoryDeck.elm
@@ -5,7 +5,7 @@ import Assets exposing (AssetPath(..), path)
 import Copy.BrandCopy exposing (relatedInfo)
 import Copy.Keys exposing (Key(..))
 import Copy.Render exposing (toHtml, toString)
-import Html exposing (Html, a, blockquote, div, h3, img, p, span, text)
+import Html exposing (Html, a, article, blockquote, div, h3, img, p, span, text)
 import Html.Attributes exposing (alt, class, href, src)
 import Html.Events exposing (onClick)
 import Icon exposing (getIcon)
@@ -58,15 +58,15 @@ storyTeaser deckId =
         t =
             toString
     in
-    a
-        [ class "card link--unstyled", href ("#/stories/" ++ String.fromInt deckId), onClick (ButtonPress "story" "view-single" (t (storyTitle deckId)) False) ]
+    article
+        [ class "card link--unstyled", onClick (ButtonPress "story" "view-single" (t (storyTitle deckId)) False) ]
         [ img [ class "card--thumbnail", src (storyTeaserImgPath deckId), alt (t (storyTeaserImgAltText deckId)) ] []
         , h3 [ class "title--small" ] [ text (t (storyTitle deckId)) ]
         , blockquote [ class "card--quote" ]
             [ text (t (getDeck deckId decks).teaser) ]
         , div [ class "text-right text-with-icon--right stories--more-link" ]
-            [ span
-                [ class "link" ]
+            [ a
+                [ class "link", href ("#/stories/" ++ String.fromInt deckId) ]
                 [ text (t (StoriesTeaserMoreLink (t (storyTitle deckId))))
                 ]
             , span [] [ getIcon "arrow-right" (Just "icon--alternate") ]

--- a/src/StoryDeck.elm
+++ b/src/StoryDeck.elm
@@ -59,7 +59,7 @@ storyTeaser deckId =
             toString
     in
     article
-        [ class "card link--unstyled", onClick (ButtonPress "story" "view-single" (t (storyTitle deckId)) False) ]
+        [ class "card card--link", onClick (NavigateToString ("#/stories/" ++ String.fromInt deckId)) ]
         [ img [ class "card--thumbnail", src (storyTeaserImgPath deckId), alt (t (storyTeaserImgAltText deckId)) ] []
         , h3 [ class "title--small" ] [ text (t (storyTitle deckId)) ]
         , blockquote [ class "card--quote" ]

--- a/src/StoryDeck.elm
+++ b/src/StoryDeck.elm
@@ -5,7 +5,7 @@ import Assets exposing (AssetPath(..), path)
 import Copy.BrandCopy exposing (relatedInfo)
 import Copy.Keys exposing (Key(..))
 import Copy.Render exposing (toHtml, toString)
-import Html exposing (Html, a, blockquote, div, h3, img, p, text)
+import Html exposing (Html, a, blockquote, div, h3, img, p, span, text)
 import Html.Attributes exposing (alt, class, href, src)
 import Html.Events exposing (onClick)
 import Icon exposing (getIcon)
@@ -58,37 +58,18 @@ storyTeaser deckId =
         t =
             toString
     in
-    div [ class "card" ]
-        [ a
-            [ href ("#/stories/" ++ String.fromInt deckId)
-            , onClick (ButtonPress "story" "view-single" (t (storyTitle deckId)) False)
-            ]
-            [ img [ class "card--thumbnail", src (storyTeaserImgPath deckId), alt (t (storyTeaserImgAltText deckId)) ] []
-            ]
-        , a
-            [ class "link--unstyled"
-            , href ("#/stories/" ++ String.fromInt deckId)
-            , onClick (ButtonPress "story" "view-single" (t (storyTitle deckId)) False)
-            ]
-            [ h3 [ class "title--small" ] [ text (t (storyTitle deckId)) ]
-            ]
+    a
+        [ class "card link--unstyled", href ("#/stories/" ++ String.fromInt deckId), onClick (ButtonPress "story" "view-single" (t (storyTitle deckId)) False) ]
+        [ img [ class "card--thumbnail", src (storyTeaserImgPath deckId), alt (t (storyTeaserImgAltText deckId)) ] []
+        , h3 [ class "title--small" ] [ text (t (storyTitle deckId)) ]
         , blockquote [ class "card--quote" ]
             [ text (t (getDeck deckId decks).teaser) ]
         , div [ class "text-right text-with-icon--right stories--more-link" ]
-            [ a
-                [ class "link"
-                , href ("#/stories/" ++ String.fromInt deckId)
-                , onClick (ButtonPress "story" "view-single" (t (storyTitle deckId)) False)
-                ]
+            [ span
+                [ class "link" ]
                 [ text (t (StoriesTeaserMoreLink (t (storyTitle deckId))))
                 ]
-            , a
-                [ class "link--unstyled"
-                , href ("#/stories/" ++ String.fromInt deckId)
-                , onClick (ButtonPress "story" "view-single" (t (storyTitle deckId)) False)
-                ]
-                [ getIcon "arrow-right" (Just "icon--alternate")
-                ]
+            , span [] [ getIcon "arrow-right" (Just "icon--alternate") ]
             ]
         ]
 

--- a/src/Update.elm
+++ b/src/Update.elm
@@ -31,6 +31,14 @@ update msg model =
         --
         -- Navigation messages
         --
+        NavigateToString url ->
+            ( model
+            , Cmd.batch
+                [ Navigation.load url
+                , updateAnalytics model (updateAnalyticsPage (pageSlug model.currentPage))
+                ]
+            )
+
         UrlChanged url ->
             let
                 newPage =

--- a/src/Update.elm
+++ b/src/Update.elm
@@ -35,7 +35,7 @@ update msg model =
             ( model
             , Cmd.batch
                 [ Navigation.load url
-                , updateAnalytics model (updateAnalyticsPage (pageSlug model.currentPage))
+                , updateAnalytics model (updateAnalyticsPage (pageSlug model.currentPage ++ " onClick navigation"))
                 ]
             )
 

--- a/src/Views/Footer.elm
+++ b/src/Views/Footer.elm
@@ -7,7 +7,6 @@ import Copy.Keys exposing (Key(..))
 import Copy.Render exposing (toHtml)
 import Html exposing (Html, a, div, footer, text)
 import Html.Attributes exposing (class, href)
-import Html.Events exposing (onClick)
 import Messages exposing (Msg(..))
 
 

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -345,8 +345,9 @@ h5 {
   background-color: $white;
 }
 
-.card.link--unstyled:hover {
+.card--link:hover {
   background-color: $grey-light-purple;
+  cursor: pointer;
 
   .link {
     color: $interaction-colour;

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -345,6 +345,18 @@ h5 {
   background-color: $white;
 }
 
+.card.link--unstyled:hover {
+  background-color: $grey-light-purple;
+
+  .link {
+    color: $interaction-colour;
+  }
+
+  .icon-arrow-right {
+    color: $interaction-colour;
+  }
+}
+
 .card--alternate {
   color: $white-pure;
   background-color: $primary-colour;


### PR DESCRIPTION
Fixes #159 

## Description

- Makes the whole card a link
- Link now only read out once, though description a little long
- Requires theme.scss update in ca-hh

![image](https://user-images.githubusercontent.com/32434620/63444880-54fec300-c42f-11e9-9336-59298e8141e2.png)

@neontribe/contemplating-action
